### PR TITLE
Remove unnecessary methods

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,13 +1,2 @@
 class StaticPagesController < ApplicationController
-  def home
-  end
-
-  def help
-  end
-
-  def about
-  end
-
-  def contact
-  end
 end


### PR DESCRIPTION
Railsチュートリアルでは流れをわかりやすくするためにコントローラ側に必ずアクションを記述するようになっておりますが、実はコントローラ側で何も処理しない場合にはアクションを定義せずともそのままテンプレートを表示までしてくれるのでした。

ということで、当該メソッドを削除してみました :-)